### PR TITLE
chore(ci): install libsystemd-dev in ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Install libsystemd-dev
+        run: sudo apt-get install libsystemd-dev
       - name: Checkout
         uses: actions/checkout@v2
       - name: golangci-lint
@@ -21,6 +23,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Install libsystemd-dev
+        run: sudo apt-get install libsystemd-dev
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
@@ -37,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Install libsystemd-dev
+        run: sudo apt-get install libsystemd-dev
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
This fixes failures caused by missing systemd headers.

Signed-off-by: Erik Swanson <erik@retailnext.net>